### PR TITLE
feat: allow more method in cors

### DIFF
--- a/src/main/java/com/example/marco/MarcoApplication.java
+++ b/src/main/java/com/example/marco/MarcoApplication.java
@@ -19,7 +19,8 @@ public class MarcoApplication {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
-						.allowedOrigins("*");
+						.allowedOrigins("*")
+						.allowedMethods("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS");
 			}
 		};
 	}


### PR DESCRIPTION
default only GET POST and HEAD is allow

by adding:
.allowedMethods(...)

it will allow PUT DELETE ... to be used in cors